### PR TITLE
Fixed key release not registering right

### DIFF
--- a/kernel/devices/kb.c
+++ b/kernel/devices/kb.c
@@ -118,7 +118,7 @@ void keyboard_handler(__attribute__((unused)) struct regs *r) {
   scancode = inb(0x60);
   // If the top bit of the scancode is set, a key has just been released
   if (scancode & 0x80) {
-    if (scancode >> 2 == 42 || scancode >> 2 == 54) {
+    if (scancode ^ 0x80 == 42 || scancode ^ 0x80 == 54) {
       state.shift_held = 0;
     }
   } else {


### PR DESCRIPTION
you have to check for bit 7, but you can't just shift it, because that will give wrong results. You need to invert the bit. It is possible to invert the bit, because you already know that it is set.

example of what happened before:
14 is pressed, 35 is released
42 is pressed, 42 is released
54 is pressed, 45 is released